### PR TITLE
Change `impl IntoResponse` into `Response<Body>`

### DIFF
--- a/examples/cron/Cargo.lock
+++ b/examples/cron/Cargo.lock
@@ -1396,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
  "bitflags",
  "bytes",
@@ -1554,7 +1554,7 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "vercel_runtime"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "base64 0.10.1",

--- a/examples/cron/Cargo.toml
+++ b/examples/cron/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = { version = "1.0.86", features = ["raw_value"] }
 serde_derive = "1.0.9"
 rand = "0.8.5"
-vercel_runtime = "0.1.4"
+vercel_runtime = { version = "0.1.4", path = "../../vercel_runtime" }
 slack-morphism = { version = "1.2.2", features = ["hyper"] }
 
 [[bin]]

--- a/examples/cron/api/cron.rs
+++ b/examples/cron/api/cron.rs
@@ -1,8 +1,5 @@
 use slack_morphism::{errors::SlackClientError, prelude::*};
-use vercel_runtime::{
-    lambda_http::{http::StatusCode, Response},
-    run, Error, IntoResponse, Request,
-};
+use vercel_runtime::{run, Body, Error, Request, Response, StatusCode};
 
 #[derive(Debug, Clone)]
 pub struct SlackMessage {}
@@ -31,12 +28,12 @@ impl<T: SlackClientHttpConnector + Send + Sync> Lambda<'_, T> {
         self.slack.chat_post_message(&post_chat_req).await
     }
 
-    pub async fn handler(&self, _req: Request) -> Result<impl IntoResponse, Error> {
+    pub async fn handler(&self, _req: Request) -> Result<Response<Body>, Error> {
         let message = SlackMessage {};
 
         self.post_message(&message, "#general").await?;
 
-        let response = Response::builder().status(StatusCode::OK).body(())?;
+        let response = Response::builder().status(StatusCode::OK).body(().into())?;
         Ok(response)
     }
 }

--- a/examples/merged/Cargo.lock
+++ b/examples/merged/Cargo.lock
@@ -867,8 +867,6 @@ dependencies = [
 [[package]]
 name = "vercel_runtime"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe80dda2c13ae59ced0917e7fc231561d58d24c6e5de111fb1453d712e1201f"
 dependencies = [
  "async-trait",
  "base64 0.10.1",

--- a/examples/merged/Cargo.toml
+++ b/examples/merged/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = { version = "1.0.86", features = ["raw_value"] }
 serde_derive = "1.0.9"
 rand = "0.8.5"
-vercel_runtime = "0.1.4"
+vercel_runtime = { version = "0.1.4", path = "../../vercel_runtime" }
 url = "2.3.1"
 
 [lib]

--- a/examples/merged/api/bar/baz.rs
+++ b/examples/merged/api/bar/baz.rs
@@ -1,11 +1,8 @@
 use runtime_demo::choose_starter;
 use serde_json::json;
-use vercel_runtime::{
-    lambda_http::{http::StatusCode, Response},
-    Error, IntoResponse, Request,
-};
+use vercel_runtime::{lambda_http::http::StatusCode, Body, Error, Request, Response};
 
-pub async fn handler(_req: Request) -> Result<impl IntoResponse, Error> {
+pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
     dbg!(_req);
     let starter = choose_starter();
     let response = Response::builder()
@@ -15,7 +12,8 @@ pub async fn handler(_req: Request) -> Result<impl IntoResponse, Error> {
             json!({
               "message": format!("I choose you, {}!", starter),
             })
-            .to_string(),
+            .to_string()
+            .into(),
         )?;
 
     Ok(response)

--- a/examples/merged/api/bar/baz.rs
+++ b/examples/merged/api/bar/baz.rs
@@ -1,6 +1,6 @@
 use runtime_demo::choose_starter;
 use serde_json::json;
-use vercel_runtime::{lambda_http::http::StatusCode, Body, Error, Request, Response};
+use vercel_runtime::{Body, Error, Request, Response, StatusCode};
 
 pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
     dbg!(_req);

--- a/examples/merged/api/foo.rs
+++ b/examples/merged/api/foo.rs
@@ -1,11 +1,8 @@
 use runtime_demo::choose_starter;
 use serde_json::json;
-use vercel_runtime::{
-    lambda_http::{http::StatusCode, Response},
-    Error, IntoResponse, Request,
-};
+use vercel_runtime::{lambda_http::http::StatusCode, Body, Error, Request, Response};
 
-pub async fn handler(_req: Request) -> Result<impl IntoResponse, Error> {
+pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
     dbg!(_req);
     let starter = choose_starter();
     let response = Response::builder()
@@ -15,7 +12,8 @@ pub async fn handler(_req: Request) -> Result<impl IntoResponse, Error> {
             json!({
               "message": format!("I choose you, {}!", starter),
             })
-            .to_string(),
+            .to_string()
+            .into(),
         )?;
 
     Ok(response)

--- a/examples/merged/api/foo.rs
+++ b/examples/merged/api/foo.rs
@@ -1,6 +1,6 @@
 use runtime_demo::choose_starter;
 use serde_json::json;
-use vercel_runtime::{lambda_http::http::StatusCode, Body, Error, Request, Response};
+use vercel_runtime::{Body, Error, Request, Response, StatusCode};
 
 pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
     dbg!(_req);

--- a/examples/merged/api/index.rs
+++ b/examples/merged/api/index.rs
@@ -1,4 +1,4 @@
-use vercel_runtime::{run, Error, IntoResponse, Request};
+use vercel_runtime::{run, Body, Error, Request, Response};
 
 #[path = "../api/bar/baz.rs"]
 mod api_bar_baz;
@@ -6,7 +6,7 @@ mod api_bar_baz;
 #[path = "../api/foo.rs"]
 mod api_foo;
 
-async fn process_request(request: Request) -> Result<impl IntoResponse, Error> {
+async fn process_request(request: Request) -> Result<Response<Body>, Error> {
     let path = request.uri().path();
 
     match path {

--- a/examples/nextjs/Cargo.lock
+++ b/examples/nextjs/Cargo.lock
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
  "bitflags",
  "bytes",
@@ -874,9 +874,7 @@ dependencies = [
 
 [[package]]
 name = "vercel_runtime"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fa94c22eab28e06f89363b1c3acb654c9084a62ac6d376e8eed1f20b470419"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "base64 0.10.1",

--- a/examples/nextjs/Cargo.toml
+++ b/examples/nextjs/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = { version = "1.0.86", features = ["raw_value"] }
 serde_derive = "1.0.9"
 rand = "0.8.5"
-vercel_runtime = "0.1.4"
+vercel_runtime = { version = "0.1.4", path = "../../vercel_runtime" }
 oorandom = "11.1.3"
 
 [[bin]]

--- a/examples/nextjs/api/rust.rs
+++ b/examples/nextjs/api/rust.rs
@@ -1,16 +1,13 @@
 use serde_json::json;
 use std::time::Instant;
-use vercel_runtime::{
-    lambda_http::{http::StatusCode, Error as LambdaError, Response},
-    run, Error, IntoResponse, Request,
-};
+use vercel_runtime::{run, Body, Error, Request, Response, StatusCode};
 
 #[tokio::main]
-async fn main() -> Result<(), LambdaError> {
+async fn main() -> Result<(), Error> {
     run(handler).await
 }
 
-pub async fn handler(_req: Request) -> Result<impl IntoResponse, Error> {
+pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
     let start = Instant::now();
 
     let seed = 42;
@@ -44,7 +41,8 @@ pub async fn handler(_req: Request) -> Result<impl IntoResponse, Error> {
                 "time": format!("{:.2?}", duration),
                 "pi": pi
             })
-            .to_string(),
+            .to_string()
+            .into(),
         )?;
 
     Ok(response)

--- a/examples/nextjs/api/rust.rs
+++ b/examples/nextjs/api/rust.rs
@@ -41,7 +41,6 @@ pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
                 "time": format!("{:.2?}", duration),
                 "pi": pi
             })
-            .to_string()
             .into(),
         )?;
 

--- a/examples/simple/Cargo.lock
+++ b/examples/simple/Cargo.lock
@@ -866,8 +866,6 @@ dependencies = [
 [[package]]
 name = "vercel_runtime"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe80dda2c13ae59ced0917e7fc231561d58d24c6e5de111fb1453d712e1201f"
 dependencies = [
  "async-trait",
  "base64 0.10.1",

--- a/examples/simple/Cargo.lock
+++ b/examples/simple/Cargo.lock
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
  "bitflags",
  "bytes",
@@ -865,7 +865,9 @@ dependencies = [
 
 [[package]]
 name = "vercel_runtime"
-version = "0.1.3"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe80dda2c13ae59ced0917e7fc231561d58d24c6e5de111fb1453d712e1201f"
 dependencies = [
  "async-trait",
  "base64 0.10.1",

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = { version = "1.0.86", features = ["raw_value"] }
 serde_derive = "1.0.9"
 rand = "0.8.5"
-vercel_runtime = "0.1.4"
+vercel_runtime = { version = "0.1.4", path = "../../vercel_runtime" }
 
 [lib]
 path = "src-rs/lib.rs"

--- a/examples/simple/api/complex.rs
+++ b/examples/simple/api/complex.rs
@@ -1,8 +1,8 @@
 use runtime_demo::choose_starter;
 use serde_json::json;
 use vercel_runtime::{
-    lambda_http::{http::StatusCode, service_fn, tower::ServiceBuilder, Response},
-    lambda_runtime, process_request, process_response, Error, IntoResponse, Request,
+    process_request, process_response, run_service, service_fn, Body, Error, Request, Response,
+    ServiceBuilder, StatusCode,
 };
 
 #[tokio::main]
@@ -19,10 +19,10 @@ async fn main() -> Result<(), Error> {
         .map_response(process_response)
         .service(service_fn(handler));
 
-    lambda_runtime::run(handler).await
+    run_service(handler).await
 }
 
-pub async fn handler(_req: Request) -> Result<impl IntoResponse, Error> {
+pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
     tracing::info!("Choosing a starter Pokemon");
     let starter = choose_starter();
 
@@ -33,7 +33,8 @@ pub async fn handler(_req: Request) -> Result<impl IntoResponse, Error> {
             json!({
               "message": format!("I choose you, {}!", starter),
             })
-            .to_string(),
+            .to_string()
+            .into(),
         )?;
 
     Ok(response)

--- a/examples/simple/api/complex.rs
+++ b/examples/simple/api/complex.rs
@@ -33,7 +33,6 @@ pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
             json!({
               "message": format!("I choose you, {}!", starter),
             })
-            .to_string()
             .into(),
         )?;
 

--- a/examples/simple/api/simple.rs
+++ b/examples/simple/api/simple.rs
@@ -1,16 +1,13 @@
 use runtime_demo::choose_starter;
 use serde_json::json;
-use vercel_runtime::{
-    lambda_http::{http::StatusCode, Response},
-    run, Error, IntoResponse, Request,
-};
+use vercel_runtime::{run, Body, Error, Request, Response, StatusCode};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     run(handler).await
 }
 
-pub async fn handler(_req: Request) -> Result<impl IntoResponse, Error> {
+pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
     let starter = choose_starter();
     let response = Response::builder()
         .status(StatusCode::OK)
@@ -19,7 +16,8 @@ pub async fn handler(_req: Request) -> Result<impl IntoResponse, Error> {
             json!({
               "message": format!("I choose you, {}!", starter),
             })
-            .to_string(),
+            .to_string()
+            .into(),
         )?;
 
     Ok(response)

--- a/examples/simple/api/simple.rs
+++ b/examples/simple/api/simple.rs
@@ -9,6 +9,7 @@ async fn main() -> Result<(), Error> {
 
 pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
     let starter = choose_starter();
+
     let response = Response::builder()
         .status(StatusCode::OK)
         .header("Content-Type", "application/json")
@@ -16,7 +17,6 @@ pub async fn handler(_req: Request) -> Result<Response<Body>, Error> {
             json!({
               "message": format!("I choose you, {}!", starter),
             })
-            .to_string()
             .into(),
         )?;
 

--- a/vercel_runtime/src/body.rs
+++ b/vercel_runtime/src/body.rs
@@ -52,20 +52,15 @@ use std::{borrow::Cow, ops::Deref, str};
 ///   _ => false
 /// })
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq)]
 pub enum Body {
     /// An empty body
+    #[default]
     Empty,
     /// A body containing string data
     Text(String),
     /// A body containing binary data
     Binary(Vec<u8>),
-}
-
-impl Default for Body {
-    fn default() -> Self {
-        Body::Empty
-    }
 }
 
 impl From<()> for Body {

--- a/vercel_runtime/src/body.rs
+++ b/vercel_runtime/src/body.rs
@@ -1,6 +1,7 @@
 //! Provides a Vercel Lambda oriented request and response body entity interface
 use base64::display::Base64Display;
 use serde::ser::{Error as SerError, Serialize, Serializer};
+use serde_json::Value;
 use std::{borrow::Cow, ops::Deref, str};
 
 /// Representation of http request and response bodies as supported
@@ -141,6 +142,12 @@ impl From<Body> for Vec<u8> {
             Body::Text(t) => t.into_bytes(),
             Body::Binary(b) => b,
         }
+    }
+}
+
+impl From<Value> for Body {
+    fn from(v: Value) -> Self {
+        Body::Text(v.to_string())
     }
 }
 

--- a/vercel_runtime/src/lib.rs
+++ b/vercel_runtime/src/lib.rs
@@ -1,20 +1,21 @@
-pub mod body;
-pub mod request;
-pub mod response;
-pub use lambda_http;
-use lambda_http::{service_fn, tower::ServiceBuilder, Response as LambdaResponse};
-pub use lambda_runtime;
+mod body;
+mod request;
+mod response;
 use lambda_runtime::LambdaEvent;
 use request::{VercelEvent, VercelRequest};
-use response::VercelResponse;
+use response::EventResponse;
 use std::future::Future;
 use tracing::{debug, error};
 
 pub type Request = lambda_http::http::Request<Body>;
 pub type Error = lambda_http::Error;
-
+pub type Event<'a> = LambdaEvent<VercelEvent<'a>>;
 pub use body::Body;
+pub use lambda_http::http::StatusCode;
+pub use lambda_http::service_fn;
+pub use lambda_http::tower::ServiceBuilder;
 pub use lambda_http::Response;
+pub use lambda_runtime::run as run_service;
 
 pub async fn run<T: FnMut(Request) -> F, F: Future<Output = Result<Response<Body>, Error>>>(
     f: T,
@@ -27,8 +28,8 @@ pub async fn run<T: FnMut(Request) -> F, F: Future<Output = Result<Response<Body
     lambda_runtime::run(handler).await
 }
 
-pub fn process_request(lambda_event: LambdaEvent<VercelEvent>) -> lambda_http::http::Request<Body> {
-    let (event, _context) = lambda_event.into_parts();
+pub fn process_request(event: Event) -> Request {
+    let (event, _context) = event.into_parts();
     let parse_result = serde_json::from_str::<VercelRequest>(&event.body);
 
     match parse_result {
@@ -45,6 +46,6 @@ pub fn process_request(lambda_event: LambdaEvent<VercelEvent>) -> lambda_http::h
     }
 }
 
-pub fn process_response(response: LambdaResponse<Body>) -> VercelResponse {
-    VercelResponse::from(response)
+pub fn process_response(response: Response<Body>) -> EventResponse {
+    EventResponse::from(response)
 }

--- a/vercel_runtime/src/lib.rs
+++ b/vercel_runtime/src/lib.rs
@@ -1,13 +1,11 @@
 pub mod body;
 pub mod request;
 pub mod response;
-use body::Body;
 pub use lambda_http;
-use lambda_http::{service_fn, tower::ServiceBuilder};
+use lambda_http::{service_fn, tower::ServiceBuilder, Response as LambdaResponse};
 pub use lambda_runtime;
 use lambda_runtime::LambdaEvent;
 use request::{VercelEvent, VercelRequest};
-pub use response::IntoResponse;
 use response::VercelResponse;
 use std::future::Future;
 use tracing::{debug, error};
@@ -15,7 +13,10 @@ use tracing::{debug, error};
 pub type Request = lambda_http::http::Request<Body>;
 pub type Error = lambda_http::Error;
 
-pub async fn run<T: FnMut(Request) -> F, F: Future<Output = Result<impl IntoResponse, Error>>>(
+pub use body::Body;
+pub use lambda_http::Response;
+
+pub async fn run<T: FnMut(Request) -> F, F: Future<Output = Result<Response<Body>, Error>>>(
     f: T,
 ) -> Result<(), Error> {
     let handler = ServiceBuilder::new()
@@ -44,6 +45,6 @@ pub fn process_request(lambda_event: LambdaEvent<VercelEvent>) -> lambda_http::h
     }
 }
 
-pub fn process_response(response: impl IntoResponse) -> VercelResponse {
-    VercelResponse::from(response.into_response())
+pub fn process_response(response: LambdaResponse<Body>) -> VercelResponse {
+    VercelResponse::from(response)
 }

--- a/vercel_runtime/src/request.rs
+++ b/vercel_runtime/src/request.rs
@@ -26,7 +26,7 @@ pub struct VercelEvent<'a> {
     #[allow(dead_code)]
     #[serde(rename = "Action")]
     action: Cow<'a, str>,
-    pub body: Cow<'a, str>,
+    pub(crate) body: Cow<'a, str>,
 }
 
 fn deserialize_method<'de, D>(deserializer: D) -> Result<Method, D::Error>

--- a/vercel_runtime/src/response.rs
+++ b/vercel_runtime/src/response.rs
@@ -1,6 +1,5 @@
 use crate::body::Body;
 use lambda_http::http::{
-    self,
     header::{HeaderMap, HeaderValue},
     Response,
 };
@@ -62,58 +61,5 @@ where
             headers: parts.headers,
             encoding,
         }
-    }
-}
-
-/// A conversion of self into a `Response`
-///
-/// Implementations for `Response<B> where B: Into<Body>`,
-/// `B where B: Into<Body>` and `serde_json::Value` are provided
-/// by default
-///
-/// # example
-///
-/// ```rust
-/// use vercel_runtime::{Body, IntoResponse, Response};
-///
-/// assert_eq!(
-///   "hello".into_response().body(),
-///   Response::new(Body::from("hello")).body()
-/// );
-/// ```
-pub(crate) trait IntoResponse {
-    /// Return a translation of `self` into a `Response<Body>`
-    fn into_response(self) -> Response<Body>;
-}
-
-impl<B> IntoResponse for Response<B>
-where
-    B: Into<Body>,
-{
-    fn into_response(self) -> Response<Body> {
-        let (parts, body) = self.into_parts();
-        Response::from_parts(parts, body.into())
-    }
-}
-
-impl<B> IntoResponse for B
-where
-    B: Into<Body>,
-{
-    fn into_response(self) -> Response<Body> {
-        Response::new(self.into())
-    }
-}
-
-impl IntoResponse for serde_json::Value {
-    fn into_response(self) -> Response<Body> {
-        Response::builder()
-            .header(http::header::CONTENT_TYPE, "application/json")
-            .body(
-                serde_json::to_string(&self)
-                    .expect("unable to serialize serde_json::Value")
-                    .into(),
-            )
-            .expect("unable to build http::Response")
     }
 }

--- a/vercel_runtime/src/response.rs
+++ b/vercel_runtime/src/response.rs
@@ -9,20 +9,20 @@ use serde_derive::Serialize;
 
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct VercelResponse {
-    pub status_code: u16,
+pub struct EventResponse {
+    pub(crate) status_code: u16,
     #[serde(
         skip_serializing_if = "HeaderMap::is_empty",
         serialize_with = "serialize_headers"
     )]
-    pub headers: HeaderMap<HeaderValue>,
+    pub(crate) headers: HeaderMap<HeaderValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<Body>,
+    pub(crate) body: Option<Body>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub encoding: Option<String>,
+    pub(crate) encoding: Option<String>,
 }
 
-impl Default for VercelResponse {
+impl Default for EventResponse {
     fn default() -> Self {
         Self {
             status_code: 200,
@@ -45,7 +45,7 @@ where
     map.end()
 }
 
-impl<T> From<Response<T>> for VercelResponse
+impl<T> From<Response<T>> for EventResponse
 where
     T: Into<Body>,
 {
@@ -56,7 +56,7 @@ where
             b @ Body::Text(_) => (None, Some(b)),
             b @ Body::Binary(_) => (Some("base64".to_string()), Some(b)),
         };
-        VercelResponse {
+        EventResponse {
             status_code: parts.status.as_u16(),
             body,
             headers: parts.headers,
@@ -81,7 +81,7 @@ where
 ///   Response::new(Body::from("hello")).body()
 /// );
 /// ```
-pub trait IntoResponse {
+pub(crate) trait IntoResponse {
     /// Return a translation of `self` into a `Response<Body>`
     fn into_response(self) -> Response<Body>;
 }


### PR DESCRIPTION
- Rework all examples to use the Response types
- Change some of the package types to ensure they stay internal
- Change `LambdaEvent<VercelEvent>` naming to `Event`, and `VercelResponse` into `EventResponse`

This should make handling routing internally possible, and adds a bit of clarity around naming, as we go: 
Event -> Request -> Response -> EventResponse. 
rather than the previous: 
LambdaEvent<VercelEvent> -> Request -> impl IntoResponse -> VercelResponse. 